### PR TITLE
feat: Add JsonUpdate and JsonQuery scalar udfs

### DIFF
--- a/dagger-functions/src/main/java/io/odpf/dagger/functions/udfs/factories/FunctionFactory.java
+++ b/dagger-functions/src/main/java/io/odpf/dagger/functions/udfs/factories/FunctionFactory.java
@@ -42,6 +42,7 @@ import io.odpf.dagger.functions.udfs.scalar.TimeInDate;
 import io.odpf.dagger.functions.udfs.scalar.TimestampFromUnix;
 import io.odpf.dagger.functions.udfs.scalar.JsonQuery;
 import io.odpf.dagger.functions.udfs.scalar.JsonUpdate;
+import io.odpf.dagger.functions.udfs.scalar.JsonDelete;
 import io.odpf.dagger.functions.udfs.table.HistogramBucket;
 import io.odpf.dagger.functions.udfs.table.OutlierMad;
 
@@ -109,6 +110,7 @@ public class FunctionFactory extends UdfFactory {
         scalarUdfs.add(new ByteToString());
         scalarUdfs.add(new JsonQuery());
         scalarUdfs.add(new JsonUpdate());
+        scalarUdfs.add(new JsonDelete());
         return scalarUdfs;
     }
 

--- a/dagger-functions/src/main/java/io/odpf/dagger/functions/udfs/factories/FunctionFactory.java
+++ b/dagger-functions/src/main/java/io/odpf/dagger/functions/udfs/factories/FunctionFactory.java
@@ -40,6 +40,8 @@ import io.odpf.dagger.functions.udfs.scalar.StartOfMonth;
 import io.odpf.dagger.functions.udfs.scalar.StartOfWeek;
 import io.odpf.dagger.functions.udfs.scalar.TimeInDate;
 import io.odpf.dagger.functions.udfs.scalar.TimestampFromUnix;
+import io.odpf.dagger.functions.udfs.scalar.JsonQuery;
+import io.odpf.dagger.functions.udfs.scalar.JsonUpdate;
 import io.odpf.dagger.functions.udfs.table.HistogramBucket;
 import io.odpf.dagger.functions.udfs.table.OutlierMad;
 
@@ -105,6 +107,8 @@ public class FunctionFactory extends UdfFactory {
         scalarUdfs.add(new ArrayAggregate());
         scalarUdfs.add(new ArrayOperate());
         scalarUdfs.add(new ByteToString());
+        scalarUdfs.add(new JsonQuery());
+        scalarUdfs.add(new JsonUpdate());
         return scalarUdfs;
     }
 

--- a/dagger-functions/src/main/java/io/odpf/dagger/functions/udfs/scalar/JsonDelete.java
+++ b/dagger-functions/src/main/java/io/odpf/dagger/functions/udfs/scalar/JsonDelete.java
@@ -1,0 +1,29 @@
+package io.odpf.dagger.functions.udfs.scalar;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.PathNotFoundException;
+import io.odpf.dagger.common.udfs.ScalarUdf;
+import org.apache.flink.table.annotation.DataTypeHint;
+
+import java.io.Serializable;
+
+/**
+ * The Json delete udf.
+ */
+public class JsonDelete extends ScalarUdf implements Serializable {
+
+    /**
+     * Deletes JSON node or value from a JSON path.
+     * The result is always returned as a JSON STRING.
+     *
+     * @param jsonEvent the json String
+     * @param jPath     the jPath
+     * @return jsonString
+     */
+    public @DataTypeHint("STRING") String eval(String jsonEvent, String jPath) throws PathNotFoundException {
+        Configuration configuration = Configuration.defaultConfiguration().setOptions(Option.DEFAULT_PATH_LEAF_TO_NULL);
+        return JsonPath.using(configuration).parse(jsonEvent).delete(JsonPath.compile(jPath)).jsonString();
+    }
+}

--- a/dagger-functions/src/main/java/io/odpf/dagger/functions/udfs/scalar/JsonQuery.java
+++ b/dagger-functions/src/main/java/io/odpf/dagger/functions/udfs/scalar/JsonQuery.java
@@ -27,9 +27,9 @@ public class JsonQuery extends ScalarUdf implements Serializable {
      */
     public @DataTypeHint("STRING") String eval(@DataTypeHint("STRING") String jsonEvent, @DataTypeHint("STRING") String jPath) throws JsonProcessingException {
         Configuration configuration = Configuration.defaultConfiguration().setOptions(Option.DEFAULT_PATH_LEAF_TO_NULL);
-        Object object = JsonPath.using(configuration).parse(jsonEvent).read(JsonPath.compile(jPath));
+        Object jChildObject = JsonPath.using(configuration).parse(jsonEvent).read(JsonPath.compile(jPath));
         ObjectMapper mapper = new ObjectMapper();
         mapper.setSerializationInclusion(JsonInclude.Include.USE_DEFAULTS);
-        return Objects.isNull(object) ? null : mapper.writeValueAsString(object);
+        return Objects.isNull(jChildObject) ? null : mapper.writeValueAsString(jChildObject);
     }
 }

--- a/dagger-functions/src/main/java/io/odpf/dagger/functions/udfs/scalar/JsonQuery.java
+++ b/dagger-functions/src/main/java/io/odpf/dagger/functions/udfs/scalar/JsonQuery.java
@@ -1,0 +1,35 @@
+package io.odpf.dagger.functions.udfs.scalar;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import io.odpf.dagger.common.udfs.ScalarUdf;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.table.annotation.DataTypeHint;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * The Json query udf.
+ */
+public class JsonQuery extends ScalarUdf implements Serializable {
+
+    /**
+     * Extracts JSON values from a JSON string.
+     * The result is always returned as a JSON STRING.
+     *
+     * @param jsonEvent the json String
+     * @param jPath     the jPath
+     * @return jsonString
+     */
+    public @DataTypeHint("STRING") String eval(@DataTypeHint("STRING") String jsonEvent, @DataTypeHint("STRING") String jPath) throws JsonProcessingException {
+        Configuration configuration = Configuration.defaultConfiguration().setOptions(Option.DEFAULT_PATH_LEAF_TO_NULL);
+        Object object = JsonPath.using(configuration).parse(jsonEvent).read(JsonPath.compile(jPath));
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setSerializationInclusion(JsonInclude.Include.USE_DEFAULTS);
+        return Objects.isNull(object) ? null : mapper.writeValueAsString(object);
+    }
+}

--- a/dagger-functions/src/main/java/io/odpf/dagger/functions/udfs/scalar/JsonUpdate.java
+++ b/dagger-functions/src/main/java/io/odpf/dagger/functions/udfs/scalar/JsonUpdate.java
@@ -1,0 +1,31 @@
+package io.odpf.dagger.functions.udfs.scalar;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.PathNotFoundException;
+import io.odpf.dagger.common.udfs.ScalarUdf;
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.annotation.InputGroup;
+
+import java.io.Serializable;
+
+/**
+ * The Json update udf.
+ */
+public class JsonUpdate extends ScalarUdf implements Serializable {
+
+    /**
+     * Updates JSON  from a JSON path.
+     * The result is always returned as a JSON STRING.
+     *
+     * @param jsonEvent the json String
+     * @param jPath     the jPath
+     * @param newValue       the new object value
+     * @return jsonString
+     */
+    public @DataTypeHint("STRING") String eval(String jsonEvent, String jPath, @DataTypeHint(inputGroup = InputGroup.ANY) Object newValue) throws PathNotFoundException {
+        Configuration configuration = Configuration.defaultConfiguration().setOptions(Option.DEFAULT_PATH_LEAF_TO_NULL);
+        return JsonPath.using(configuration).parse(jsonEvent).set(JsonPath.compile(jPath), newValue).jsonString();
+    }
+}

--- a/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/factories/FunctionFactoryTest.java
+++ b/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/factories/FunctionFactoryTest.java
@@ -1,17 +1,45 @@
 package io.odpf.dagger.functions.udfs.factories;
 
-import io.odpf.dagger.functions.udfs.scalar.*;
+import io.odpf.dagger.functions.udfs.aggregate.CollectArray;
+import io.odpf.dagger.functions.udfs.aggregate.DistinctCount;
+import io.odpf.dagger.functions.udfs.aggregate.Features;
+import io.odpf.dagger.functions.udfs.aggregate.FeaturesWithType;
+import io.odpf.dagger.functions.udfs.aggregate.PercentileAggregator;
+import io.odpf.dagger.functions.udfs.scalar.ArrayAggregate;
+import io.odpf.dagger.functions.udfs.scalar.ArrayOperate;
+import io.odpf.dagger.functions.udfs.scalar.ByteToString;
+import io.odpf.dagger.functions.udfs.scalar.CondEq;
+import io.odpf.dagger.functions.udfs.scalar.DartContains;
+import io.odpf.dagger.functions.udfs.scalar.DartGet;
+import io.odpf.dagger.functions.udfs.scalar.Distance;
+import io.odpf.dagger.functions.udfs.scalar.ElementAt;
+import io.odpf.dagger.functions.udfs.scalar.EndOfMonth;
+import io.odpf.dagger.functions.udfs.scalar.EndOfWeek;
+import io.odpf.dagger.functions.udfs.scalar.ExponentialMovingAverage;
+import io.odpf.dagger.functions.udfs.scalar.Filters;
+import io.odpf.dagger.functions.udfs.scalar.FormatTimeInZone;
+import io.odpf.dagger.functions.udfs.scalar.GeoHash;
+import io.odpf.dagger.functions.udfs.scalar.LinearTrend;
+import io.odpf.dagger.functions.udfs.scalar.ListContains;
+import io.odpf.dagger.functions.udfs.scalar.MapGet;
+import io.odpf.dagger.functions.udfs.scalar.S2AreaInKm2;
+import io.odpf.dagger.functions.udfs.scalar.S2Id;
+import io.odpf.dagger.functions.udfs.scalar.SelectFields;
+import io.odpf.dagger.functions.udfs.scalar.SingleFeatureWithType;
+import io.odpf.dagger.functions.udfs.scalar.Split;
+import io.odpf.dagger.functions.udfs.scalar.StartOfMonth;
+import io.odpf.dagger.functions.udfs.scalar.StartOfWeek;
+import io.odpf.dagger.functions.udfs.scalar.TimeInDate;
+import io.odpf.dagger.functions.udfs.scalar.TimestampFromUnix;
+import io.odpf.dagger.functions.udfs.scalar.JsonQuery;
+import io.odpf.dagger.functions.udfs.scalar.JsonUpdate;
+import io.odpf.dagger.functions.udfs.scalar.JsonDelete;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 
 import io.odpf.dagger.common.configuration.Configuration;
 import io.odpf.dagger.common.udfs.AggregateUdf;
 import io.odpf.dagger.common.udfs.ScalarUdf;
 import io.odpf.dagger.common.udfs.TableUdf;
-import io.odpf.dagger.functions.udfs.aggregate.CollectArray;
-import io.odpf.dagger.functions.udfs.aggregate.DistinctCount;
-import io.odpf.dagger.functions.udfs.aggregate.Features;
-import io.odpf.dagger.functions.udfs.aggregate.FeaturesWithType;
-import io.odpf.dagger.functions.udfs.aggregate.PercentileAggregator;
 import io.odpf.dagger.functions.udfs.table.HistogramBucket;
 import io.odpf.dagger.functions.udfs.table.OutlierMad;
 import org.junit.Assert;
@@ -93,6 +121,7 @@ public class FunctionFactoryTest {
         verify(streamTableEnvironment, times(1)).createTemporaryFunction(eq("ArrayOperate"), any(ArrayOperate.class));
         verify(streamTableEnvironment, times(1)).createTemporaryFunction(eq("ByteToString"), any(ByteToString.class));
         verify(streamTableEnvironment, times(1)).createTemporaryFunction(eq("JsonUpdate"), any(JsonUpdate.class));
+        verify(streamTableEnvironment, times(1)).createTemporaryFunction(eq("JsonDelete"), any(JsonDelete.class));
         verify(streamTableEnvironment, times(1)).createTemporaryFunction(eq("JsonQuery"), any(JsonQuery.class));
     }
 

--- a/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/factories/FunctionFactoryTest.java
+++ b/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/factories/FunctionFactoryTest.java
@@ -1,5 +1,6 @@
 package io.odpf.dagger.functions.udfs.factories;
 
+import io.odpf.dagger.functions.udfs.scalar.*;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 
 import io.odpf.dagger.common.configuration.Configuration;
@@ -11,32 +12,6 @@ import io.odpf.dagger.functions.udfs.aggregate.DistinctCount;
 import io.odpf.dagger.functions.udfs.aggregate.Features;
 import io.odpf.dagger.functions.udfs.aggregate.FeaturesWithType;
 import io.odpf.dagger.functions.udfs.aggregate.PercentileAggregator;
-import io.odpf.dagger.functions.udfs.scalar.ArrayAggregate;
-import io.odpf.dagger.functions.udfs.scalar.ArrayOperate;
-import io.odpf.dagger.functions.udfs.scalar.ByteToString;
-import io.odpf.dagger.functions.udfs.scalar.CondEq;
-import io.odpf.dagger.functions.udfs.scalar.DartContains;
-import io.odpf.dagger.functions.udfs.scalar.DartGet;
-import io.odpf.dagger.functions.udfs.scalar.Distance;
-import io.odpf.dagger.functions.udfs.scalar.ElementAt;
-import io.odpf.dagger.functions.udfs.scalar.EndOfMonth;
-import io.odpf.dagger.functions.udfs.scalar.EndOfWeek;
-import io.odpf.dagger.functions.udfs.scalar.ExponentialMovingAverage;
-import io.odpf.dagger.functions.udfs.scalar.Filters;
-import io.odpf.dagger.functions.udfs.scalar.FormatTimeInZone;
-import io.odpf.dagger.functions.udfs.scalar.GeoHash;
-import io.odpf.dagger.functions.udfs.scalar.LinearTrend;
-import io.odpf.dagger.functions.udfs.scalar.ListContains;
-import io.odpf.dagger.functions.udfs.scalar.MapGet;
-import io.odpf.dagger.functions.udfs.scalar.S2AreaInKm2;
-import io.odpf.dagger.functions.udfs.scalar.S2Id;
-import io.odpf.dagger.functions.udfs.scalar.SelectFields;
-import io.odpf.dagger.functions.udfs.scalar.SingleFeatureWithType;
-import io.odpf.dagger.functions.udfs.scalar.Split;
-import io.odpf.dagger.functions.udfs.scalar.StartOfMonth;
-import io.odpf.dagger.functions.udfs.scalar.StartOfWeek;
-import io.odpf.dagger.functions.udfs.scalar.TimeInDate;
-import io.odpf.dagger.functions.udfs.scalar.TimestampFromUnix;
 import io.odpf.dagger.functions.udfs.table.HistogramBucket;
 import io.odpf.dagger.functions.udfs.table.OutlierMad;
 import org.junit.Assert;
@@ -117,6 +92,8 @@ public class FunctionFactoryTest {
         verify(streamTableEnvironment, times(1)).createTemporaryFunction(eq("ArrayAggregate"), any(ArrayAggregate.class));
         verify(streamTableEnvironment, times(1)).createTemporaryFunction(eq("ArrayOperate"), any(ArrayOperate.class));
         verify(streamTableEnvironment, times(1)).createTemporaryFunction(eq("ByteToString"), any(ByteToString.class));
+        verify(streamTableEnvironment, times(1)).createTemporaryFunction(eq("JsonUpdate"), any(JsonUpdate.class));
+        verify(streamTableEnvironment, times(1)).createTemporaryFunction(eq("JsonQuery"), any(JsonQuery.class));
     }
 
     @Test

--- a/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/scalar/JsonDeleteTest.java
+++ b/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/scalar/JsonDeleteTest.java
@@ -59,7 +59,7 @@ public class JsonDeleteTest {
     }
 
     @Test
-    public void  shouldDeleteNestedValueAndReturnAsJsonString() {
+    public void shouldDeleteNestedValueAndReturnAsJsonString() {
         JsonDelete jsonDelete = new JsonDelete();
         String jsonEvent = "{\"k1\":\"v1\",\"k2\":{\"key1\":\"value1\",\"key2\":\"value2\",\"key3\":\"value3\"}}";
         String expectedJsonEvent = "{\"k1\":\"v1\",\"k2\":{\"key2\":\"value2\",\"key3\":\"value3\"}}";

--- a/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/scalar/JsonDeleteTest.java
+++ b/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/scalar/JsonDeleteTest.java
@@ -39,7 +39,7 @@ public class JsonDeleteTest {
     }
 
     @Test
-    public void shouldReturnDeletedValueAsJsonString() {
+    public void shouldDeleteValueAndReturnAsJsonString() {
         JsonDelete jsonDelete = new JsonDelete();
         String jsonEvent = "{\"k1\":\"v1\",\"k2\":\"v2\"}";
         String expectedJsonEvent = "{\"k1\":\"v1\"}";
@@ -49,7 +49,7 @@ public class JsonDeleteTest {
     }
 
     @Test
-    public void shouldReturnDeletedNodeAsJsonString() {
+    public void shouldDeleteNodeValueAndReturnAsJsonString() {
         JsonDelete jsonDelete = new JsonDelete();
         String jsonEvent = "{\"k1\":\"v1\",\"k2\":{\"key1\":\"value1\",\"key2\":\"value2\",\"key3\":\"value3\"}}";
         String expectedJsonEvent = "{\"k1\":\"v1\"}";
@@ -59,7 +59,7 @@ public class JsonDeleteTest {
     }
 
     @Test
-    public void shouldReturnDeletedNestedValueAsJsonString() {
+    public void  shouldDeleteNestedValueAndReturnAsJsonString() {
         JsonDelete jsonDelete = new JsonDelete();
         String jsonEvent = "{\"k1\":\"v1\",\"k2\":{\"key1\":\"value1\",\"key2\":\"value2\",\"key3\":\"value3\"}}";
         String expectedJsonEvent = "{\"k1\":\"v1\",\"k2\":{\"key2\":\"value2\",\"key3\":\"value3\"}}";
@@ -69,7 +69,7 @@ public class JsonDeleteTest {
     }
 
     @Test
-    public void shouldReturnDeletedArrayValueAsJsonString() {
+    public void shouldDeleteArrayValueAndReturnAsJsonString() {
         JsonDelete jsonDelete = new JsonDelete();
         String jsonEvent = "{\"k1\":\"v1\",\"k2\":[\"value1\",\"value2\",\"value3\"]}";
         String expectedJsonEvent = "{\"k1\":\"v1\",\"k2\":[\"value1\",\"value3\"]}";

--- a/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/scalar/JsonDeleteTest.java
+++ b/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/scalar/JsonDeleteTest.java
@@ -1,0 +1,148 @@
+package io.odpf.dagger.functions.udfs.scalar;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.table.functions.FunctionContext;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class JsonDeleteTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+    @Mock
+    private MetricGroup metricGroup;
+
+    @Mock
+    private FunctionContext functionContext;
+
+    @Before
+    public void setup() {
+        initMocks(this);
+        when(functionContext.getMetricGroup()).thenReturn(metricGroup);
+        when(metricGroup.addGroup("udf", "JsonDelete")).thenReturn(metricGroup);
+    }
+
+    @Test
+    public void shouldRegisterGauge() throws Exception {
+        JsonDelete jsonDelete = new JsonDelete();
+        jsonDelete.open(functionContext);
+        verify(metricGroup, times(1)).gauge(any(String.class), any(Gauge.class));
+    }
+
+    @Test
+    public void shouldReturnDeletedValueAsJsonString() {
+        JsonDelete jsonDelete = new JsonDelete();
+        String jsonEvent = "{\"k1\":\"v1\",\"k2\":\"v2\"}";
+        String expectedJsonEvent = "{\"k1\":\"v1\"}";
+        String jPath = "$.k2";
+        String actual = jsonDelete.eval(jsonEvent, jPath);
+        Assert.assertEquals(expectedJsonEvent, actual);
+    }
+
+    @Test
+    public void shouldReturnDeletedNodeAsJsonString() {
+        JsonDelete jsonDelete = new JsonDelete();
+        String jsonEvent = "{\"k1\":\"v1\",\"k2\":{\"key1\":\"value1\",\"key2\":\"value2\",\"key3\":\"value3\"}}";
+        String expectedJsonEvent = "{\"k1\":\"v1\"}";
+        String jPath = "$.k2";
+        String actual = jsonDelete.eval(jsonEvent, jPath);
+        Assert.assertEquals(expectedJsonEvent, actual);
+    }
+
+    @Test
+    public void shouldReturnDeletedNestedValueAsJsonString() {
+        JsonDelete jsonDelete = new JsonDelete();
+        String jsonEvent = "{\"k1\":\"v1\",\"k2\":{\"key1\":\"value1\",\"key2\":\"value2\",\"key3\":\"value3\"}}";
+        String expectedJsonEvent = "{\"k1\":\"v1\",\"k2\":{\"key2\":\"value2\",\"key3\":\"value3\"}}";
+        String jPath = "$.k2.key1";
+        String actual = jsonDelete.eval(jsonEvent, jPath);
+        Assert.assertEquals(expectedJsonEvent, actual);
+    }
+
+    @Test
+    public void shouldReturnDeletedArrayValueAsJsonString() {
+        JsonDelete jsonDelete = new JsonDelete();
+        String jsonEvent = "{\"k1\":\"v1\",\"k2\":[\"value1\",\"value2\",\"value3\"]}";
+        String expectedJsonEvent = "{\"k1\":\"v1\",\"k2\":[\"value1\",\"value3\"]}";
+        String jPath = "$.k2[1]";
+        String actual = jsonDelete.eval(jsonEvent, jPath);
+        Assert.assertEquals(expectedJsonEvent, actual);
+    }
+
+    @Test
+    public void shouldReturnEmptyJsonAsJsonString() {
+        JsonDelete jsonDelete = new JsonDelete();
+        String jsonEvent = "{\"k1\":\"v1\",\"k2\":[\"value1\",\"value2\",\"value3\"]}";
+        String expectedJsonEvent = "{}";
+        String jPath = "$..*";
+        String actual = jsonDelete.eval(jsonEvent, jPath);
+        Assert.assertEquals(expectedJsonEvent, actual);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenNullJsonEvent() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("json string can not be null or empty");
+        JsonDelete jsonDelete = new JsonDelete();
+        String jsonEvent = null;
+        String jPath = "$.k2";
+        jsonDelete.eval(jsonEvent, jPath);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenNullJPath() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("json can not be null or empty");
+        JsonDelete jsonDelete = new JsonDelete();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
+        String jPath = null;
+        jsonDelete.eval(jsonEvent, jPath);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenEmptyJPath() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("json can not be null or empty");
+        JsonDelete jsonDelete = new JsonDelete();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
+        String jPath = "";
+        jsonDelete.eval(jsonEvent, jPath);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenImproperJPath() {
+        thrown.expect(com.jayway.jsonpath.InvalidPathException.class);
+        thrown.expectMessage("Illegal character at position 1 expected '.' or '[");
+        JsonDelete jsonDelete = new JsonDelete();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
+        String jPath = "$ .k1";
+        jsonDelete.eval(jsonEvent, jPath);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenInvalidJPath() {
+        thrown.expect(com.jayway.jsonpath.PathNotFoundException.class);
+        JsonDelete jsonDelete = new JsonDelete();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
+        String jPath = "$.k2.k4";
+        jsonDelete.eval(jsonEvent, jPath);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenInvalidJsonEvent() {
+        thrown.expect(com.jayway.jsonpath.InvalidJsonException.class);
+        JsonDelete jsonDelete = new JsonDelete();
+        String jsonEvent = "{\"k1\":null,\"k2\"\"v2\"}";
+        String jPath = "$.k2";
+        jsonDelete.eval(jsonEvent, jPath);
+    }
+}

--- a/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/scalar/JsonQueryTest.java
+++ b/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/scalar/JsonQueryTest.java
@@ -114,4 +114,12 @@ public class JsonQueryTest {
         String jPath = "$.k2.k4";
         jsonQuery.eval(jsonEvent, jPath);
     }
+    @Test
+    public void shouldThrowErrorWhenInvalidJsonEvent() throws JsonProcessingException {
+        thrown.expect(com.jayway.jsonpath.InvalidJsonException.class);
+        JsonQuery jsonQuery = new JsonQuery();
+        String jsonEvent = "{\"k1\":null,\"k2\"\"v2\"}";
+        String jPath = "$.k2";
+        jsonQuery.eval(jsonEvent, jPath);
+    }
 }

--- a/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/scalar/JsonQueryTest.java
+++ b/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/scalar/JsonQueryTest.java
@@ -87,12 +87,31 @@ public class JsonQueryTest {
     }
 
     @Test
+    public void shouldThrowErrorWhenEmptyJPath() throws JsonProcessingException {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("json can not be null or empty");
+        JsonQuery jsonQuery = new JsonQuery();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
+        String jPath = "";
+        jsonQuery.eval(jsonEvent, jPath);
+    }
+
+    @Test
     public void shouldThrowErrorWhenImproperJPath() throws JsonProcessingException {
         thrown.expect(com.jayway.jsonpath.InvalidPathException.class);
         thrown.expectMessage("Illegal character at position 1 expected '.' or '[");
         JsonQuery jsonQuery = new JsonQuery();
         String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
         String jPath = "$ .k1";
-        System.out.println(jsonQuery.eval(jsonEvent, jPath));
+        jsonQuery.eval(jsonEvent, jPath);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenInvalidJPath() throws JsonProcessingException {
+        thrown.expect(com.jayway.jsonpath.PathNotFoundException.class);
+        JsonQuery jsonQuery = new JsonQuery();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
+        String jPath = "$.k2.k4";
+        jsonQuery.eval(jsonEvent, jPath);
     }
 }

--- a/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/scalar/JsonQueryTest.java
+++ b/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/scalar/JsonQueryTest.java
@@ -1,0 +1,98 @@
+package io.odpf.dagger.functions.udfs.scalar;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.table.functions.FunctionContext;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class JsonQueryTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+    @Mock
+    private MetricGroup metricGroup;
+
+    @Mock
+    private FunctionContext functionContext;
+
+    @Before
+    public void setup() {
+        initMocks(this);
+        when(functionContext.getMetricGroup()).thenReturn(metricGroup);
+        when(metricGroup.addGroup("udf", "JsonQuery")).thenReturn(metricGroup);
+    }
+
+    @Test
+    public void shouldRegisterGauge() throws Exception {
+        JsonQuery jsonQuery = new JsonQuery();
+        jsonQuery.open(functionContext);
+        verify(metricGroup, times(1)).gauge(any(String.class), any(Gauge.class));
+    }
+
+    @Test
+    public void shouldReturnJsonString() throws JsonProcessingException {
+        JsonQuery jsonQuery = new JsonQuery();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
+        String expectedJsonEvent = "\"v2\"";
+        String jPath = "$.k2";
+        Assert.assertEquals(expectedJsonEvent, jsonQuery.eval(jsonEvent, jPath));
+    }
+
+    @Test
+    public void shouldReturnJsonStringForNestedJson() throws JsonProcessingException {
+        JsonQuery jsonQuery = new JsonQuery();
+        String expectedJsonEvent = "{\"key1\":\"value1\",\"key2\":\"value2\"}";
+        String jsonEvent = "{\"k1\":null,\"k2\":{\"key1\":\"value1\",\"key2\":\"value2\"}}";
+        String jPath = "$.k2";
+        Assert.assertEquals(expectedJsonEvent, jsonQuery.eval(jsonEvent, jPath));
+    }
+
+    @Test
+    public void shouldReturnJsonStringForNullValue() throws JsonProcessingException {
+        JsonQuery jsonQuery = new JsonQuery();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
+        String jPath = "$.k1";
+        String result = jsonQuery.eval(jsonEvent, jPath);
+        Assert.assertNull(result);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenNullJsonEvent() throws JsonProcessingException {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("json string can not be null or empty");
+        JsonQuery jsonQuery = new JsonQuery();
+        String jsonEvent = null;
+        String jPath = "$.k2";
+        jsonQuery.eval(jsonEvent, jPath);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenNullJPath() throws JsonProcessingException {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("json can not be null or empty");
+        JsonQuery jsonQuery = new JsonQuery();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
+        String jPath = null;
+        jsonQuery.eval(jsonEvent, jPath);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenImproperJPath() throws JsonProcessingException {
+        thrown.expect(com.jayway.jsonpath.InvalidPathException.class);
+        thrown.expectMessage("Illegal character at position 1 expected '.' or '[");
+        JsonQuery jsonQuery = new JsonQuery();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
+        String jPath = "$ .k1";
+        System.out.println(jsonQuery.eval(jsonEvent, jPath));
+    }
+}

--- a/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/scalar/JsonUpdateTest.java
+++ b/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/scalar/JsonUpdateTest.java
@@ -1,0 +1,180 @@
+package io.odpf.dagger.functions.udfs.scalar;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.table.functions.FunctionContext;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class JsonUpdateTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+    @Mock
+    private MetricGroup metricGroup;
+
+    @Mock
+    private FunctionContext functionContext;
+
+    @Before
+    public void setup() {
+        initMocks(this);
+        when(functionContext.getMetricGroup()).thenReturn(metricGroup);
+        when(metricGroup.addGroup("udf", "JsonUpdate")).thenReturn(metricGroup);
+    }
+
+    @Test
+    public void shouldRegisterGauge() throws Exception {
+        JsonUpdate jsonUpdate = new JsonUpdate();
+        jsonUpdate.open(functionContext);
+        verify(metricGroup, times(1)).gauge(any(String.class), any(Gauge.class));
+    }
+
+    @Test
+    public void shouldReturnAddedJsonStringForEmptyJsonWithNewKeyValue() {
+        JsonUpdate jsonUpdate = new JsonUpdate();
+        String jsonEvent = "{}";
+        String expectedJsonEvent = "{\"k1\":\"v1\"}";
+        String jPath = "$.k1";
+        String updateValue = "v1";
+        String actual = jsonUpdate.eval(jsonEvent, jPath, updateValue);
+        System.out.println(actual);
+        Assert.assertEquals(expectedJsonEvent, actual);
+    }
+
+    @Test
+    public void shouldReturnAddedJsonStringForNewKeyValuePair() {
+        JsonUpdate jsonUpdate = new JsonUpdate();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
+        String expectedJsonEvent = "{\"k1\":null,\"k2\":\"v2\",\"k3\":\"v3\"}";
+        String jPath = "$.k3";
+        String updateValue = "v3";
+        Assert.assertEquals(expectedJsonEvent, jsonUpdate.eval(jsonEvent, jPath, updateValue));
+    }
+
+    @Test
+    public void shouldReturnAddedJsonString() {
+        JsonUpdate jsonUpdate = new JsonUpdate();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
+        String expectedJsonEvent = "{\"k1\":null,\"k2\":\"updatedValue\"}";
+        String jPath = "$.k2";
+        String updateValue = "updatedValue";
+        Assert.assertEquals(expectedJsonEvent, jsonUpdate.eval(jsonEvent, jPath, updateValue));
+    }
+
+    @Test
+    public void shouldReturnAddedJsonStringForNestedJson() {
+        JsonUpdate jsonUpdate = new JsonUpdate();
+        String jsonEvent = "{\"k1\":null,\"k2\":{\"key1\":\"value1\",\"key2\":\"value2\"}}";
+        String expectedJsonEvent = "{\"k1\":null,\"k2\":{\"key1\":\"value1\",\"key2\":\"value2\",\"key3\":\"value3\"}}";
+        String jPath = "$.k2.key3";
+        String updateValue = "value3";
+        String actual = jsonUpdate.eval(jsonEvent, jPath, updateValue);
+        Assert.assertEquals(expectedJsonEvent, actual);
+    }
+
+    @Test
+    public void shouldReturnUpdatedJsonStringForNestedJson() {
+        JsonUpdate jsonUpdate = new JsonUpdate();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
+        String expectedJsonEvent = "{\"k1\":null,\"k2\":{\"key1\":\"value1\",\"key2\":\"value2\"}}";
+        String jPath = "$.k2";
+        Map<String, String> updateValue = new HashMap<String, String>() {{
+            put("key1", "value1");
+            put("key2", "value2");
+        }};
+        Assert.assertEquals(expectedJsonEvent, jsonUpdate.eval(jsonEvent, jPath, updateValue));
+    }
+
+    @Test
+    public void shouldReturnUpdatedJsonStringForNullValue() {
+        JsonUpdate jsonUpdate = new JsonUpdate();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
+        String expectedJsonEvent = "{\"k1\":null,\"k2\":null}";
+        String jPath = "$.k2";
+        String updateValue = null;
+        Assert.assertEquals(expectedJsonEvent, jsonUpdate.eval(jsonEvent, jPath, updateValue));
+    }
+
+    @Test
+    public void shouldReturnUpdatedJsonStringForNewNestedKeyValue() {
+        JsonUpdate jsonUpdate = new JsonUpdate();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
+        String expectedJsonEvent = "{\"k1\":null,\"k2\":\"v2\",\"k3\":{\"key1\":\"value1\",\"key2\":\"value2\"}}";
+        String jPath = "$.k3";
+        Map<String, String> updateValue = new HashMap<String, String>() {{
+            put("key1", "value1");
+            put("key2", "value2");
+        }};
+        String actual = jsonUpdate.eval(jsonEvent, jPath, updateValue);
+        Assert.assertEquals(expectedJsonEvent, actual);
+    }
+
+    @Test
+    public void shouldReturnUpdatedJsonStringForNewNestedKeyValueInNestedPath() {
+        JsonUpdate jsonUpdate = new JsonUpdate();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\",\"k3\":{\"nk1\":\"nv1\",\"nk2\":\"nv2\"}}";
+        String expectedJsonEvent = "{\"k1\":null,\"k2\":\"v2\",\"k3\":{\"nk1\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"nk2\":\"nv2\"}}";
+        String jPath = "$.k3.nk1";
+        Map<String, String> updateValue = new HashMap<String, String>() {{
+            put("key1", "value1");
+            put("key2", "value2");
+        }};
+        String actual = jsonUpdate.eval(jsonEvent, jPath, updateValue);
+        Assert.assertEquals(expectedJsonEvent, actual);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenNullJsonEvent() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("json string can not be null or empty");
+        JsonUpdate jsonUpdate = new JsonUpdate();
+        String jsonEvent = null;
+        String jPath = "$.k2";
+        String updateValue = "updatedValue";
+        jsonUpdate.eval(jsonEvent, jPath, updateValue);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenNullJPath() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("json can not be null or empty");
+        JsonUpdate jsonUpdate = new JsonUpdate();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
+        String jPath = null;
+        String updateValue = "updatedValue";
+        jsonUpdate.eval(jsonEvent, jPath, updateValue);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenImproperJPath() {
+        thrown.expect(com.jayway.jsonpath.InvalidPathException.class);
+        thrown.expectMessage("Illegal character at position 1 expected '.' or '[");
+        JsonUpdate jsonUpdate = new JsonUpdate();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
+        String jPath = "$ .k1";
+        String updateValue = "updatedValue";
+        jsonUpdate.eval(jsonEvent, jPath, updateValue);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenInvalidJPath() {
+        thrown.expect(com.jayway.jsonpath.PathNotFoundException.class);
+        JsonUpdate jsonUpdate = new JsonUpdate();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
+        String jPath = "$.k2.k4";
+        String updateValue = "updatedValue";
+        jsonUpdate.eval(jsonEvent, jPath, updateValue);
+    }
+}

--- a/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/scalar/JsonUpdateTest.java
+++ b/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/scalar/JsonUpdateTest.java
@@ -187,4 +187,13 @@ public class JsonUpdateTest {
         String updateValue = "updatedValue";
         jsonUpdate.eval(jsonEvent, jPath, updateValue);
     }
+    @Test
+    public void shouldThrowErrorWhenInvalidJsonEvent() {
+        thrown.expect(com.jayway.jsonpath.InvalidJsonException.class);
+        JsonUpdate jsonUpdate = new JsonUpdate();
+        String jsonEvent = "{\"k1\":null,\"k2\"\"v2\"}";
+        String jPath = "$.k2";
+        String updateValue = "updatedValue";
+        jsonUpdate.eval(jsonEvent, jPath, updateValue);
+    }
 }

--- a/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/scalar/JsonUpdateTest.java
+++ b/dagger-functions/src/test/java/io/odpf/dagger/functions/udfs/scalar/JsonUpdateTest.java
@@ -49,7 +49,6 @@ public class JsonUpdateTest {
         String jPath = "$.k1";
         String updateValue = "v1";
         String actual = jsonUpdate.eval(jsonEvent, jPath, updateValue);
-        System.out.println(actual);
         Assert.assertEquals(expectedJsonEvent, actual);
     }
 
@@ -153,6 +152,17 @@ public class JsonUpdateTest {
         JsonUpdate jsonUpdate = new JsonUpdate();
         String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
         String jPath = null;
+        String updateValue = "updatedValue";
+        jsonUpdate.eval(jsonEvent, jPath, updateValue);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenEmptyJPath() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("json can not be null or empty");
+        JsonUpdate jsonUpdate = new JsonUpdate();
+        String jsonEvent = "{\"k1\":null,\"k2\":\"v2\"}";
+        String jPath = "";
         String updateValue = "updatedValue";
         jsonUpdate.eval(jsonEvent, jPath, updateValue);
     }

--- a/docs/docs/reference/udfs.md
+++ b/docs/docs/reference/udfs.md
@@ -34,6 +34,8 @@ The udfs on Dagger divided into two parts:
   - [StartOfWeek](udfs.md#StartOfWeek)
   - [TimeInDate](udfs.md#TimeInDate)
   - [TimestampFromUnix](udfs.md#TimestampFromUnix)
+  - [JsonUpdate](udfs.md#JsonUpdate)
+  - [JsonQuery](udfs.md#JsonQuery)
 - [Aggregate Functions](udfs.md#aggregate-functions)
   - [CollectArray](udfs.md#CollectArray)
   - [DistinctCount](udfs.md#DistinctCount)
@@ -648,6 +650,46 @@ SELECT
 FROM 
   data_stream
 ```
+
+#### JsonUpdate
+ * Contract: 
+   * **String** `JsonUpdate(String jsonEvent, String jPath, Object newValue)`
+ * Functionality:
+   * Returns the json string with updated value in a given jsonPath. 
+   * It uses special notation (JsonPath) and it traverses nodes and their connections to adjacent nodes mentioned in a JsonPath and updates the existing json with the provided newValue.
+ * Example:
+   * Example 1: Adds the new key k3 with value v3 to the existing Json
+```
+SELECT 
+  JsonUpdate('{"k1":null,"k2":"v2"}','$.k3','v3') AS T
+FROM 
+  data_stream
+```
+Result: `{"k1":null,"k2":"v2","k2":"v3"}`
+
+   * Example 2: Updates the new value v1 to the existing Json at jpath $.k1
+```
+SELECT 
+  JsonUpdate('{"k1":null,"k2":"v2"}','$.k1','v1') AS T
+FROM 
+  data_stream
+```
+Result: `{"k1":"v1","k2":"v2"}`
+
+#### JsonQuery
+* Contract:
+  * **String** `JsonQuery(String jsonEvent, String jPath)`
+* Functionality:
+  * Returns the json string with child object mentioned in jsonPath.
+  * It uses special notation (JsonPath) and it traverses nodes and their connections to adjacent nodes mentioned in a JsonPath and extracts the value.
+* Example:
+```
+SELECT 
+  JsonQuery('{"k1":null,"k2":{"key1":"value1","key2":"value2"}}','$.k2') AS T
+FROM 
+  data_stream
+```
+Result: `{"key1":"value1","key2":"value2"}`
 
 ### Aggregate Functions
 

--- a/docs/docs/reference/udfs.md
+++ b/docs/docs/reference/udfs.md
@@ -659,22 +659,57 @@ FROM
    * It uses special notation (JsonPath) and it traverses nodes and their connections to adjacent nodes mentioned in a JsonPath and updates the existing json with the provided newValue.
  * Example:
    * Example 1: Adds the new key k3 with value v3 to the existing Json
-```
-SELECT 
-  JsonUpdate('{"k1":null,"k2":"v2"}','$.k3','v3') AS T
-FROM 
-  data_stream
-```
-Result: `{"k1":null,"k2":"v2","k2":"v3"}`
+    ```
+    SELECT 
+      JsonUpdate('{"k1":null,"k2":"v2"}','$.k3','v3') AS T
+    FROM 
+      data_stream
+    ```
+    Result: `{"k1":null,"k2":"v2","k2":"v3"}`
 
-   * Example 2: Updates the new value v1 to the existing Json at jpath $.k1
-```
-SELECT 
-  JsonUpdate('{"k1":null,"k2":"v2"}','$.k1','v1') AS T
-FROM 
-  data_stream
-```
-Result: `{"k1":"v1","k2":"v2"}`
+   * Example 2: Updates the new value v1 to the existing Json at jpath `$.k1`
+    ```
+    SELECT 
+      JsonUpdate('{"k1":null,"k2":"v2"}','$.k1','v1') AS T
+    FROM 
+      data_stream
+    ```
+    Result: `{"k1":"v1","k2":"v2"}`
+
+
+#### JsonDelete
+* Contract:
+  * **String** `JsonDelete(String jsonEvent, String jPath)`
+* Functionality:
+  * Returns the json string with deleted value/node based on the mentioned jsonPath.
+  * It uses special notation (JsonPath) and it traverses nodes and their connections to adjacent nodes mentioned in a JsonPath and deletes the existing value or node.
+* Example:
+  * Example 1: Deletes the key value pair at jsonPath `$.k1`
+   ```
+   SELECT 
+     JsonDelete('{"k1":null,"k2":"v2"}','$.k1') AS T
+   FROM 
+     data_stream
+   ```
+  Result: `{"k2":"v2"}`
+
+  * Example 2: Deletes the json node at jsonPath `$.k2`
+   ```
+   SELECT 
+     JsonDelete('{"k1":"v1","k2":{"key1":"value1","key2":"value2"}}','$.k2') AS T
+   FROM 
+     data_stream
+   ```
+  Result: `{"k1":"v1"}`
+
+  * Example 3: Deletes the json index element value mentioned in the jsonpath `$.k2[1]`
+   ```
+   SELECT 
+     JsonDelete('{"k1":"v1","k2":["value1","value2","value3"]}',$.k2[1]) AS T
+   FROM 
+     data_stream
+   ```
+  Result: `{"k1":"v1","k2":["value1","value3"]}`
 
 #### JsonQuery
 * Contract:

--- a/docs/docs/reference/udfs.md
+++ b/docs/docs/reference/udfs.md
@@ -36,6 +36,7 @@ The udfs on Dagger divided into two parts:
   - [TimestampFromUnix](udfs.md#TimestampFromUnix)
   - [JsonUpdate](udfs.md#JsonUpdate)
   - [JsonQuery](udfs.md#JsonQuery)
+  - [JsonDelete](udfs.md#JsonDelete)
 - [Aggregate Functions](udfs.md#aggregate-functions)
   - [CollectArray](udfs.md#CollectArray)
   - [DistinctCount](udfs.md#DistinctCount)


### PR DESCRIPTION
As of the current version of Flink 1.14.3, to update or to add particular value in input json object using JsonPath and to query child object from parent json using JsonPath are missing. These UDFs will help us in handling such use-cases in flink-sql.